### PR TITLE
feat: bump e2e test timeout to 15000ms

### DIFF
--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   testEnvironment: 'node',
-  testRegex: './e2e/e2e.js'
+  testRegex: './e2e/e2e.js',
+  testTimeout: 15000
 }


### PR DESCRIPTION
## Description

The getProfile API test [timed out at 5000ms](https://github.com/adobe/aio-e2e-tests/actions/runs/6476291284/job/17584773520#step:7:1164) recently. Given this test includes a network call, this may have been an intermittent issue. 

This PR proposes bumping up the test timeout for e2e tests from 5000ms (default) to 15000ms. 

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
